### PR TITLE
create_before_destroy param group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -87,6 +87,7 @@ resource "aws_elasticache_parameter_group" "redis" {
 
   # Ignore changes to the description since it will try to recreate the resource
   lifecycle {
+    create_before_destroy = true
     ignore_changes = [
       description,
     ]


### PR DESCRIPTION
revert the removal of the `create_before_destroy` flag on the parameter group.  As is, this prevents the in-place upgrade of elasticache when changing the engine and family version of redis.
noted in https://github.com/umotif-public/terraform-aws-elasticache-redis/issues/49